### PR TITLE
Fishjam-dev rebranding

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@ General purpose media server written in Elixir!
 
 Check out a bunch of helpful links:
 
-* [Jellyfish]
+* [Fishjam]
 * [Documentation]
 * [Discord]
 
@@ -21,19 +21,19 @@ Client SDKs:
 * [Android][android-client-sdk]
 
 Demos:
-* [Jellyfish Dashboard]
-* [Jellyfish Videoroom]
+* [Fishjam Dashboard]
+* [Fishjam Videoroom]
 
 
-[Jellyfish]: https://github.com/jellyfish-dev/jellyfish
-[Documentation]: https://jellyfish-dev.github.io/jellyfish-docs/
-[elixir-server-sdk]: https://github.com/jellyfish-dev/elixir_server_sdk
-[python-server-sdk]: https://github.com/jellyfish-dev/python-server-sdk
-[ts-client-sdk]: https://github.com/jellyfish-dev/ts-client-sdk
-[react-client-sdk]: https://github.com/jellyfish-dev/react-client-sdk
-[react-native-client-sdk]: https://github.com/jellyfish-dev/react-native-client-sdk 
-[ios-client-sdk]: https://github.com/jellyfish-dev/ios-client-sdk
-[android-client-sdk]: https://github.com/jellyfish-dev/android-client-sdk
-[Jellyfish Dashboard]: https://github.com/jellyfish-dev/jellyfish-dashboard
-[Jellyfish Videoroom]: https://github.com/jellyfish-dev/jellyfish_videoroom
+[Fishjam]: https://github.com/fishjam-dev/fishjam
+[Documentation]: https://fishjam-dev.github.io/fishjam-docs/
+[elixir-server-sdk]: https://github.com/fishjam-dev/elixir_server_sdk
+[python-server-sdk]: https://github.com/fishjam-dev/python-server-sdk
+[ts-client-sdk]: https://github.com/fishjam-dev/ts-client-sdk
+[react-client-sdk]: https://github.com/fishjam-dev/react-client-sdk
+[react-native-client-sdk]: https://github.com/fishjam-dev/react-native-client-sdk 
+[ios-client-sdk]: https://github.com/fishjam-dev/ios-client-sdk
+[android-client-sdk]: https://github.com/fishjam-dev/android-client-sdk
+[Fishjam Dashboard]: https://github.com/fishjam-dev/fishjam-dashboard
+[Fishjam Videoroom]: https://github.com/fishjam-dev/fishjam-videoroom
 [Discord]: https://discord.gg/8WEaKweE7P


### PR DESCRIPTION
TODO Rename repositories:
- [ ] [Fishjam]: https://github.com/fishjam-dev/fishjam
- [ ] [Documentation]: https://fishjam-dev.github.io/fishjam-docs/
